### PR TITLE
Remove debug line outputting amount set for resizing

### DIFF
--- a/lua/smart-resize/init.lua
+++ b/lua/smart-resize/init.lua
@@ -1,7 +1,6 @@
 local M = {}
 
 local function resize(direction, amount)
-  print(vim.inspect(amount))
   amount = amount or 3
   -- account for bufferline, status line, and cmd line
   local is_full_height = vim.api.nvim_win_get_height(0) == vim.o.lines - 2 - vim.o.cmdheight


### PR DESCRIPTION
## What changed

Removed `print(vim.inspect(amount))` from the plugin. This was causing the plugin to print out the value a user sets for their resize amount.


## How to test
1. Pull this branch
2. install the changes with packer
3. Confirm that the plugin is no longer echoing out the value set for amount.

```lua
use({
  "hsheikhali1/smart-resize.nvim",
  branch = "remove-debug-lines",
  config = function()
    local amount = 4
    require('smart-resize').resize_up(amount)
    require('smart-resize').resize_down(amount)
    require('smart-resize').resize_left(amount)
    require('smart-resize').resize_right(amount)
  end
})
```

### Expected outcome
It shouldn't echo out the line numbers specified.